### PR TITLE
Add onWarning when loading Espell

### DIFF
--- a/tiny-bootstrap.sh
+++ b/tiny-bootstrap.sh
@@ -145,7 +145,8 @@ function load_espell() {
 			Metacello new 
 				baseline: 'Espell';
 				repository: 'github://guillep/espell:v1.6.1/src';
-				onConflictUseIncoming ;
+				onConflictUseIncoming;
+				onWarningLog;
 				load.
 
 			(Smalltalk classNamed: 'EPASTInterpreter')


### PR DESCRIPTION
Espell loading was halted for me when I tried it.
Apparently was because of a warning.
This seems to fix that.